### PR TITLE
Add build instructions for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ connected to your AP.
 ## Build
 
 Ubuntu instructions
-You will need `make` and `build-essential` installed. Then run `make`. This will produce a `hs100` binary which you can use. E.g. `./hs100 192.168.0.1 off`
+You will need `build-essential` installed. Then run `make`. This will produce a `hs100` binary which you can use. E.g. `./hs100 192.168.0.1 off`
 
 ## Todo
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ reset the plug and try again. Otherwise, the light on your plug will change
 first to blinking blue, then to solid blue indicating that it has successfully
 connected to your AP.
 
+## Build
+
+Ubuntu instructions
+You will need `make` and `build-essential` installed. Then run `make`. This will produce a `hs100` binary which you can use. E.g. `./hs100 192.168.0.1 off`
+
 ## Todo
 
 - better error checking


### PR DESCRIPTION
I know this is kinda a petty PR but I'm not a C developer in my day-to-day so it wasn't apparent to me how to build the binary. So I added some instructions to save the next person 5-15 minutes.

Alternatively it would be cool if a binary was attached to the next and following releases so users don't have to build. 

Thank you very much for this great utility. I tried to outsmart the Kasa app by disconnecting the internet when trying to pair my smart plug to my wifi, but for some asinine reason (data collection) you have to be connected to the internet to pair. 🙄 So this was a great save!!

BTW - Another unsolicited suggestion (sorry): you might get more traffic if you give this repo a different name, it took some creative googling to find this repo. The distinguishing features are the pairing and data collection disabling when comparing it to the other TPLink repos.