### PR TITLE
Implement emeter command to query realtime power consumption for HS110

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Loosely based on [pyHS100](https://github.com/GadgetReactor/pyHS100) and
 Commands:
 - `associate <ssid> <key> <key_type>`: set wifi AP to connect to. get your
 key\_type by doing a scan
+- `emeter`: realtime power consumption (only works with HS110)
 - `factory-reset`: reset the plug to factory settings
 - `off`: turn the power off
 - `on`: turn the power on

--- a/hs100.c
+++ b/hs100.c
@@ -22,6 +22,11 @@ struct cmd_s cmds[] = {
 		.handler = handler_associate,
 	},
 	{
+		.command = "emeter",
+		.help = "emeter\t\tget realtime power consumption (only works with HS110)",
+		.json = "{\"emeter\":{\"get_realtime\":{}}}",
+	},
+	{
 		.command = "factory-reset",
 		.help = "factory-reset\treset the plug to factory settings",
 		.json = "{\"system\":{\"reset\":{\"delay\":0}}}",


### PR DESCRIPTION
Some plugs have energy monitoring capabilities like the HS110 so I've added a "emeter" command for it.

Tested with an HS110(EU) (FW 1.2.5 Build 171213 Rel.101523) and output looks like this:

```
./hs100 10.8.4.5 emeter
{"emeter":{"get_realtime":{"current":0.022636,"voltage":238.338504,"power":0.619029,"total":0.216000,"err_code":0}}}
```