### PR TITLE
Add Win32 Build Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ objects = comms.o handlers.o hs100.o escape.o
 
 CFLAGS  = -std=gnu99 -Wall -Werror
 
-OS := $(shell uname -s | tr "[:upper:]" "[:lower:]")
-$(info OS="$(OS)")
+MACHINE := $(shell $(CC) -dumpmachine)
+$(info MACHINE="$(MACHINE)")
 
-ifneq (,$(findstring mingw,$(OS)))
+ifneq (,$(findstring mingw,$(MACHINE)))
     LDFLAGS = -lws2_32
 else
     LDFLAGS = -lresolv

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,16 @@
 target  = hs100
 objects = comms.o handlers.o hs100.o escape.o
 
-CFLAGS  = -std=gnu99
-LDFLAGS = -lresolv
+CFLAGS  = -std=gnu99 -Wall -Werror
+
+OS := $(shell uname -s | tr "[:upper:]" "[:lower:]")
+$(info OS="$(OS)")
+
+ifneq (,$(findstring mingw,$(OS)))
+    LDFLAGS = -lws2_32
+else
+    LDFLAGS = -lresolv
+endif
 
 .PHONY: all
 all:	$(target)

--- a/escape.c
+++ b/escape.c
@@ -2,11 +2,11 @@
 #include <stdlib.h>
 #include "escape.h"
 
-unsigned char *escape_json(const unsigned char *orig)
+char *escape_json(const char *orig)
 {
-	unsigned char *out = NULL;
+	char *out = NULL;
 	size_t len = 0;
-	unsigned char *outp;
+	char *outp;
 
 	out = malloc(strlen((const char *)orig) * 2 + 1);
 	if (!out) {

--- a/escape.h
+++ b/escape.h
@@ -1,2 +1,2 @@
 #pragma once
-unsigned char *escape_json(const unsigned char *orig) __attribute__((nonnull(1)));
+char *escape_json(const char *orig) __attribute__((nonnull(1)));

--- a/handlers.c
+++ b/handlers.c
@@ -19,7 +19,7 @@ char *handler_associate(int argc, char *argv[])
 	size_t len;
 
 	if (password)
-		password = escape_json(password);
+		password = (char *)escape_json((const unsigned char *)password);
 
 	if (argc < 6) {
 		fprintf(stderr, "not enough arguments\n");

--- a/handlers.c
+++ b/handlers.c
@@ -19,7 +19,7 @@ char *handler_associate(int argc, char *argv[])
 	size_t len;
 
 	if (password)
-		password = (char *)escape_json((const unsigned char *)password);
+		password = escape_json(password);
 
 	if (argc < 6) {
 		fprintf(stderr, "not enough arguments\n");


### PR DESCRIPTION
This adds support for native Win32 builds, addressing #13. It can be built under the MinGW or Cygwin toolchains. The Makefile modification detects whether the compiler is part of the MinGW toolchain and links against the appropriate library.