### PR TITLE
C source cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 target  = hs100
 objects = comms.o handlers.o hs100.o escape.o
 
-CFLAGS  = -std=c99 -DDEFAULT_SOURCE -Wall -Werror
+CFLAGS  = -std=c99 -Wall -Werror
 # for those who like their warnings turned up to 11
 CFLAGS += -Wextra -Wstrict-prototypes -Wmissing-prototypes -Wshadow -pedantic
 CFLAGS += -Wpointer-arith -Wcast-align -Wcast-qual -Wwrite-strings -Wundef
+
+# also passes cppcheck --std=c99 --enable=all --suppress=missingInclude *.c
 
 MACHINE := $(shell $(CC) -dumpmachine)
 $(info MACHINE="$(MACHINE)")

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 target  = hs100
 objects = comms.o handlers.o hs100.o escape.o
 
-CFLAGS  = -std=gnu99 -Wall -Werror
+CFLAGS  = -std=c99 -DDEFAULT_SOURCE -Wall -Werror
+# for those who like their warnings turned up to 11
+CFLAGS += -Wextra -Wstrict-prototypes -Wmissing-prototypes -Wshadow -pedantic
+CFLAGS += -Wpointer-arith -Wcast-align -Wcast-qual -Wwrite-strings -Wundef
 
 MACHINE := $(shell $(CC) -dumpmachine)
 $(info MACHINE="$(MACHINE)")

--- a/comms.c
+++ b/comms.c
@@ -17,7 +17,7 @@
 
 #include "comms.h"
 
-bool hs100_encrypt(uint8_t *d, const uint8_t *s, size_t len)
+static bool hs100_encrypt(uint8_t *d, const uint8_t *s, size_t len)
 {
 	uint8_t key, temp;
 	size_t i;
@@ -38,7 +38,7 @@ bool hs100_encrypt(uint8_t *d, const uint8_t *s, size_t len)
 	return true;
 }
 
-bool hs100_decrypt(uint8_t *d, const uint8_t *s, size_t len)
+static bool hs100_decrypt(uint8_t *d, const uint8_t *s, size_t len)
 {
 	uint8_t key, temp;
 	size_t i;
@@ -59,7 +59,7 @@ bool hs100_decrypt(uint8_t *d, const uint8_t *s, size_t len)
 	return true;
 }
 
-uint8_t *hs100_encode(size_t *outlen, const char *srcmsg)
+static uint8_t *hs100_encode(size_t *outlen, const char *srcmsg)
 {
 	size_t srcmsg_len;
 	uint8_t *d;
@@ -73,7 +73,7 @@ uint8_t *hs100_encode(size_t *outlen, const char *srcmsg)
 	d = calloc(1, *outlen);
 	if (d == NULL)
 		return NULL;
-	if (!hs100_encrypt(d + 4, (uint8_t *) srcmsg, srcmsg_len)) {
+	if (!hs100_encrypt(d + 4, (const uint8_t *) srcmsg, srcmsg_len)) {
 		free(d);
 		return NULL;
 	}
@@ -83,7 +83,7 @@ uint8_t *hs100_encode(size_t *outlen, const char *srcmsg)
 	return d;
 }
 
-char *hs100_decode(const uint8_t *s, size_t s_len)
+static char *hs100_decode(const uint8_t *s, size_t s_len)
 {
 	uint32_t in_s_len;
 	char *outbuf;

--- a/comms.c
+++ b/comms.c
@@ -19,7 +19,7 @@
 
 static bool hs100_encrypt(uint8_t *d, const uint8_t *s, size_t len)
 {
-	uint8_t key, temp;
+	uint8_t key;
 	size_t i;
 
 	if (d == NULL)
@@ -31,7 +31,7 @@ static bool hs100_encrypt(uint8_t *d, const uint8_t *s, size_t len)
 
 	key = 0xab;
 	for (i = 0; i < len; i++) {
-		temp = key ^ s[i];
+		uint8_t temp = key ^ s[i];
 		key = temp;
 		d[i] = temp;
 	}
@@ -40,7 +40,7 @@ static bool hs100_encrypt(uint8_t *d, const uint8_t *s, size_t len)
 
 static bool hs100_decrypt(uint8_t *d, const uint8_t *s, size_t len)
 {
-	uint8_t key, temp;
+	uint8_t key;
 	size_t i;
 
 	if (d == NULL)
@@ -52,7 +52,7 @@ static bool hs100_decrypt(uint8_t *d, const uint8_t *s, size_t len)
 
 	key = 0xab;
 	for (i = 0; i < len; i++) {
-		temp = key ^ s[i];
+		uint8_t temp = key ^ s[i];
 		key = s[i];
 		d[i] = temp;
 	}
@@ -182,7 +182,7 @@ char *hs100_send(const char *servaddr, const char *msg)
 	}
 	msglen = ntohl(msglen) + 4;
 	recvbuf = calloc(1, (size_t) msglen);
-	recvsize = recv(sock, recvbuf, msglen, MSG_WAITALL);
+	(void) recv(sock, recvbuf, msglen, MSG_WAITALL);
 #ifdef _WIN32
 	closesocket(sock);
 #else

--- a/handlers.c
+++ b/handlers.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include "comms.h"
 #include "escape.h"
+#include "handlers.h"
 
 char *handler_associate(int argc, char *argv[])
 {

--- a/handlers.h
+++ b/handlers.h
@@ -1,0 +1,5 @@
+#pragma once
+char *handler_associate(int argc, char *argv[]);
+char *handler_set_server(int argc, char *argv[]);
+char *handler_set_relay_state(int argc, char *argv[]);
+char *handler_get_realtime(int argc, char *argv[]);

--- a/hs100.c
+++ b/hs100.c
@@ -3,17 +3,12 @@
 #include <string.h>
 #include "version.h"
 #include "comms.h"
-
-// handlers for more complicated commands
-extern char *handler_associate(int argc, char *argv[]);
-extern char *handler_set_server(int argc, char *argv[]);
-extern char *handler_set_relay_state(int argc, char *argv[]);
-extern char *handler_get_realtime(int argc, char *argv[]);
+#include "handlers.h"
 
 struct cmd_s {
-	char *command;
-	char *help;
-	char *json;
+	const char *command;
+	const char *help;
+	const char *json;
 	char *(*handler) (int argc, char *argv[]);
 };
 struct cmd_s cmds[] = {
@@ -73,7 +68,7 @@ struct cmd_s cmds[] = {
 	},
 };
 
-struct cmd_s *get_cmd_from_name(char *needle)
+static struct cmd_s *get_cmd_from_name(char *needle)
 {
 	int cmds_index = 0;
 	while (cmds[cmds_index].command) {
@@ -84,7 +79,7 @@ struct cmd_s *get_cmd_from_name(char *needle)
 	return NULL;
 }
 
-void print_usage()
+static void print_usage(void)
 {
 	fprintf(stderr, "hs100 version " VERSION_STRING
 			", Copyright (C) 2018-2019 Jason Benaim.\n"


### PR DESCRIPTION
Lint-free even with gcc warning flags turned up to 11

Only question is if y'all want the new Makefile lines
CFLAGS += -Wextra -Wstrict-prototypes -Wmissing-prototypes -Wshadow -pedantic
CFLAGS += -Wpointer-arith -Wcast-align -Wcast-qual -Wwrite-strings -Wundef
commented-out.  This patch leaves them in.